### PR TITLE
HELPS-425 - Add line break in clipboard aptitude example

### DIFF
--- a/v1/config.json
+++ b/v1/config.json
@@ -46,7 +46,7 @@
   "aptitudeWhisper": {
     "label": "Olive Helps: Clipboard Aptitude Test",
     "header": "See the Clipboard Aptitude in action",
-    "body": "By performing that copy action, you’ve successfully triggered the Clipboard Aptitude to generate this Whisper. Some Loops might use this Aptitude to display information about the text you’ve copied. For example, a Provider Directory Loop might detect if you’ve copied a healthcare provider’s name, and show you a Whisper containing information about that provider.",
+    "body": "By performing that copy action, you’ve successfully triggered the Clipboard Aptitude to generate this Whisper.  \n  \nSome Loops might use this Aptitude to display information about the text you’ve copied. For example, a Provider Directory Loop might detect if you’ve copied a healthcare provider’s name, and show you a Whisper containing information about that provider.",
     "image": ""
   }
 }


### PR DESCRIPTION
Added a couple line breaks in between some text as requested:

![2021-06-23_12-47-46](https://user-images.githubusercontent.com/73316418/123145717-bbd1d680-d422-11eb-818a-29d7c840849d.png)
